### PR TITLE
rebalance.go, rebuild.go, server.go, thrasher.go -> print out error, …

### DIFF
--- a/rebalance.go
+++ b/rebalance.go
@@ -30,22 +30,19 @@ func rebalance(db *leveldb.DB, req RebalanceRequest) bool {
   }
 
   // write
-  err = remote_put(remote_to, int64(len(ss)), strings.NewReader(ss))
-  if err != nil {
+  if err := remote_put(remote_to, int64(len(ss)), strings.NewReader(ss)); err != nil {
     fmt.Println("put error", err, remote_to)
     return false
   }
 
   // update db
-  err = db.Put(req.key, []byte(req.kvolume), nil)
-  if err != nil {
+  if err := db.Put(req.key, []byte(req.kvolume), nil); err != nil {
     fmt.Println("put db error", err)
     return false
   }
 
   // delete
-  err = remote_delete(remote_from)
-  if err != nil {
+  if err := remote_delete(remote_from); err != nil {
     fmt.Println("delete error", err, remote_from)
     return false
   }
@@ -60,7 +57,7 @@ func main() {
 
   db, err := leveldb.OpenFile(os.Args[2], nil)
   if err != nil {
-    fmt.Errorf("LevelDB open failed %s", err)
+    fmt.Println(fmt.Errorf("LevelDB open failed %s", err))
     return
   }
   defer db.Close()

--- a/rebuild.go
+++ b/rebuild.go
@@ -36,8 +36,7 @@ func rebuild(db *leveldb.DB, req RebuildRequest) bool {
       fmt.Println("ugh", err)
       return false
     }
-    err = db.Put(key, []byte(req.vol), nil)
-    if err != nil {
+    if err := db.Put(key, []byte(req.vol), nil); err != nil {
       fmt.Println("ugh", err)
       return false
     }
@@ -54,7 +53,7 @@ func main() {
 
   db, err := leveldb.OpenFile(os.Args[2], nil)
   if err != nil {
-    fmt.Errorf("LevelDB open failed %s", err)
+    fmt.Println(fmt.Errorf("LevelDB open failed %s", err))
     return
   }
   defer db.Close()

--- a/server.go
+++ b/server.go
@@ -130,8 +130,7 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
     // push to leveldb
     // note that the key is locked, so nobody wrote to the leveldb
-    err = a.db.Put(key, []byte(kvolume), nil)
-    if err != nil {
+    if err := a.db.Put(key, []byte(kvolume), nil); err != nil {
       // should we delete?
       w.WriteHeader(500)
       return
@@ -170,7 +169,7 @@ func main() {
 
   db, err := leveldb.OpenFile(os.Args[1], nil)
   if err != nil {
-    fmt.Errorf("LevelDB open failed %s", err)
+    fmt.Println(fmt.Errorf("LevelDB open failed %s", err))
     return
   }
   defer db.Close()

--- a/thrasher.go
+++ b/thrasher.go
@@ -24,8 +24,7 @@ func main() {
       for {
         key := <-reqs
         value := fmt.Sprintf("value-%d", rand.Int())
-        err := remote_put("http://localhost:3000/"+key, int64(len(value)), strings.NewReader(value))
-        if err != nil {
+        if err := remote_put("http://localhost:3000/"+key, int64(len(value)), strings.NewReader(value)); err != nil {
           fmt.Println("PUT FAILED", err)
           resp <- false
           continue
@@ -38,8 +37,7 @@ func main() {
           continue
         }
 
-        err = remote_delete("http://localhost:3000/"+key)
-        if err != nil {
+        if err := remote_delete("http://localhost:3000/"+key); err != nil {
           fmt.Println("DELETE FAILED", err)
           resp <- false
           continue


### PR DESCRIPTION
- change the way of error handling from assign error to a variable to in-line error checking
- handle fmt.Errorf() as the function is return the error var (it not print out to stdout) -> handle by using fmt.Println()