### PR TITLE
allow 404 response from volume server when deleting

### DIFF
--- a/src/lib.go
+++ b/src/lib.go
@@ -139,7 +139,7 @@ func remote_delete(remote string) error {
     return err
   }
   defer resp.Body.Close()
-  if resp.StatusCode != 204 {
+  if resp.StatusCode != 204 && resp.StatusCode != 404 {
     return fmt.Errorf("remote_delete: wrong status code %d", resp.StatusCode)
   }
   return nil


### PR DESCRIPTION
when a `PUT` request fails due to a volume server being down a record is left in the database (in soft delete state) and therefore a `DELETE` request subsequently fails because it issues a request to the volume server that was down (which returns a 404).

Seems like if there is no file to delete (note that the node does have to be up to get a 404 response) the delete should succeed (and subsequently clean up the record in the database).