### PR TITLE
md5sum command line param

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -24,6 +24,7 @@ type App struct {
   replicas int
   subvolumes int
   protect bool
+  md5sum bool
 }
 
 func (a *App) UnlockKey(key []byte) {
@@ -66,6 +67,7 @@ func main() {
   subvolumes := flag.Int("subvolumes", 10, "Amount of subvolumes, disks per machine")
   pvolumes := flag.String("volumes", "", "Volumes to use for storage, comma separated")
   protect := flag.Bool("protect", false, "Force UNLINK before DELETE")
+  md5sum := flag.Bool("md5sum", true, "Calculate and store MD5 checksum of values")
   flag.Parse()
 
   volumes := strings.Split(*pvolumes, ",")
@@ -99,6 +101,7 @@ func main() {
     replicas: *replicas,
     subvolumes: *subvolumes,
     protect: *protect,
+    md5sum: *md5sum,
   }
 
   if command == "server" {

--- a/src/server.go
+++ b/src/server.go
@@ -182,8 +182,11 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
       }
     }
 
-    // compute the hash of the value
-    hash := fmt.Sprintf("%x", md5.Sum(buf.Bytes()))
+    var hash = ""
+    if a.md5sum {
+      // compute the hash of the value
+      hash = fmt.Sprintf("%x", md5.Sum(buf.Bytes()))
+    }
 
     // push to leveldb as existing
     // note that the key is locked, so nobody wrote to the leveldb


### PR DESCRIPTION
support turning off calculating and storing MD5 checksums with `-md5sum=false` command line parameter