### PR TITLE
Fallback HEAD/GET requests faster when volume server is down

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # system basics
 RUN apt-get update && \

--- a/src/lib.go
+++ b/src/lib.go
@@ -11,6 +11,8 @@ import (
   "net/http"
   "sort"
   "strings"
+  "context"
+  "time"
 )
 
 // *** DB Type ***
@@ -178,8 +180,10 @@ func remote_get(remote string) (string, error) {
   return string(body), nil
 }
 
-func remote_head(remote string) bool {
-  req, err := http.NewRequest("HEAD", remote, nil)
+func remote_head(remote string, timeout time.Duration) bool {
+  ctx, cancel := context.WithTimeout(context.Background(), timeout)
+  defer cancel()
+  req, err := http.NewRequestWithContext(ctx, "HEAD", remote, nil)
   if err != nil {
     return false
   }

--- a/src/main.go
+++ b/src/main.go
@@ -25,6 +25,7 @@ type App struct {
   subvolumes int
   protect bool
   md5sum bool
+  voltimeout time.Duration
 }
 
 func (a *App) UnlockKey(key []byte) {
@@ -68,6 +69,7 @@ func main() {
   pvolumes := flag.String("volumes", "", "Volumes to use for storage, comma separated")
   protect := flag.Bool("protect", false, "Force UNLINK before DELETE")
   md5sum := flag.Bool("md5sum", true, "Calculate and store MD5 checksum of values")
+  voltimeout := flag.Duration("voltimeout", 1*time.Second, "Volume servers must respond to GET/HEAD requests in this amount of time or they are considered down, as duration")
   flag.Parse()
 
   volumes := strings.Split(*pvolumes, ",")
@@ -102,6 +104,7 @@ func main() {
     subvolumes: *subvolumes,
     protect: *protect,
     md5sum: *md5sum,
+    voltimeout: *voltimeout,
   }
 
   if command == "server" {

--- a/src/rebalance.go
+++ b/src/rebalance.go
@@ -4,6 +4,7 @@ import (
   "fmt"
   "sync"
   "strings"
+  "time"
 )
 
 type RebalanceRequest struct {
@@ -18,7 +19,7 @@ func rebalance(a *App, req RebalanceRequest) bool {
   // find the volumes that are real
   rvolumes := make([]string, 0)
   for _, rv := range req.volumes {
-    if remote_head(fmt.Sprintf("http://%s%s", rv, kp)) {
+    if remote_head(fmt.Sprintf("http://%s%s", rv, kp), 1*time.Second) {
       rvolumes = append(rvolumes, rv)
     }
   }

--- a/src/server.go
+++ b/src/server.go
@@ -129,7 +129,7 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
       good := false
       for _, vn := range rand.Perm(len(rec.rvolumes)) {
         remote = fmt.Sprintf("http://%s%s", rec.rvolumes[vn], key2path(key))
-        if remote_head(remote) {
+        if remote_head(remote, a.voltimeout) {
           good = true
           break
         }

--- a/tools/bringup.sh
+++ b/tools/bringup.sh
@@ -8,5 +8,5 @@ PORT=3003 ./volume /tmp/volume3/ &
 PORT=3004 ./volume /tmp/volume4/ &
 PORT=3005 ./volume /tmp/volume5/ &
 
-./mkv -volumes localhost:3001,localhost:3002,localhost:3003,localhost:3004,localhost:3005 -db /tmp/indexdb/ server
+./mkv -port 3000 -volumes localhost:3001,localhost:3002,localhost:3003,localhost:3004,localhost:3005 -db /tmp/indexdb/ server
 


### PR DESCRIPTION
When a node goes down, HEAD requests are used to randomly find a volume server that is up, and it seems to take about 5 seconds to time out by default.  This change makes the timeout configurable.

This was a lot easier on newer versions of go, so I went ahead and updated things to ubuntu 20.04