### PR TITLE
REBALANCE should fail on timeout

### DIFF
--- a/src/lib.go
+++ b/src/lib.go
@@ -180,18 +180,18 @@ func remote_get(remote string) (string, error) {
   return string(body), nil
 }
 
-func remote_head(remote string, timeout time.Duration) bool {
+func remote_head(remote string, timeout time.Duration) (bool, error) {
   ctx, cancel := context.WithTimeout(context.Background(), timeout)
   defer cancel()
   req, err := http.NewRequestWithContext(ctx, "HEAD", remote, nil)
   if err != nil {
-    return false
+    return false, err
   }
   resp, err := http.DefaultClient.Do(req)
   if err != nil {
-    return false
+    return false, err
   }
   defer resp.Body.Close()
-  return resp.StatusCode == 200
+  return resp.StatusCode == 200, nil
 }
 

--- a/src/server.go
+++ b/src/server.go
@@ -129,7 +129,8 @@ func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
       good := false
       for _, vn := range rand.Perm(len(rec.rvolumes)) {
         remote = fmt.Sprintf("http://%s%s", rec.rvolumes[vn], key2path(key))
-        if remote_head(remote, a.voltimeout) {
+        found, _ := remote_head(remote, a.voltimeout)
+        if found {
           good = true
           break
         }


### PR DESCRIPTION
REBALANCE was marking files as missing when HEAD timeout occurred, and then proceeded to PUT those files again