### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,14 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
-    - name: Install Go/nginx
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+    - name: Install nginx
       run: |
         sudo apt-get update
-        sudo apt-get -y --no-install-recommends install golang nginx build-essential
+        sudo apt-get -y --no-install-recommends install nginx build-essential
     - name: Set log permissions
       run: |
         sudo mkdir -p /var/log/nginx
@@ -28,4 +32,3 @@ jobs:
         ./tools/s3test.py
         go run tools/thrasher.go
         ./tools/rtest.sh
-

--- a/src/lib.go
+++ b/src/lib.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -174,7 +173,7 @@ func remote_get(remote string) (string, error) {
 	if resp.StatusCode != 200 {
 		return "", errors.New(fmt.Sprintf("remote_get: wrong status code %d", resp.StatusCode))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -89,7 +89,7 @@ func main() {
 	}
 
 	if !*verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	} else {
 		log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 	}

--- a/src/s3api.go
+++ b/src/s3api.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 )
 
 type CompleteMultipartUpload struct {
@@ -17,7 +16,7 @@ type Delete struct {
 }
 
 func parseXML(r io.Reader, dat interface{}) error {
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/tools/thrasher.go
+++ b/tools/thrasher.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -55,7 +54,7 @@ func remote_get(remote string) (string, error) {
 	if resp.StatusCode != 200 {
 		return "", errors.New(fmt.Sprintf("remote_get: wrong status code %d", resp.StatusCode))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR introduce two small changes:

1. Use [actions/setup-go](https://github.com/actions/setup-go) instead of installing the `golang` package from `apt`. This speeds up the workflow and allows us to update the Go version easily (packages provided by Ubuntu are often several releases behind the latest version).

2. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.