### PR TITLE
Parallelize writes to replicas

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -122,7 +122,10 @@ func main() {
 	}
 
 	if command == "server" {
-		http.ListenAndServe(fmt.Sprintf(":%d", *port), &a)
+		err := http.ListenAndServe(fmt.Sprintf(":%d", *port), &a)
+		if err != nil {
+			panic(err)
+		}
 	} else if command == "rebuild" {
 		a.Rebuild()
 	} else if command == "rebalance" {

--- a/src/rebalance.go
+++ b/src/rebalance.go
@@ -121,10 +121,11 @@ func (a *App) Rebalance() {
 	reqs := make(chan RebalanceRequest, 20000)
 
 	for i := 0; i < 16; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for req := range reqs {
 				rebalance(a, req)
-				wg.Done()
 			}
 		}()
 	}
@@ -136,7 +137,6 @@ func (a *App) Rebalance() {
 		copy(key, iter.Key())
 		rec := toRecord(iter.Value())
 		kvolumes := key2volume(key, a.volumes, a.replicas, a.subvolumes)
-		wg.Add(1)
 		reqs <- RebalanceRequest{
 			key:      key,
 			volumes:  rec.rvolumes,

--- a/src/rebuild.go
+++ b/src/rebuild.go
@@ -117,13 +117,14 @@ func (a *App) Rebuild() {
 	reqs := make(chan RebuildRequest, 20000)
 
 	for i := 0; i < 128; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for req := range reqs {
 				files := get_files(req.url)
 				for _, f := range files {
 					rebuild(a, req.vol, f.Name)
 				}
-				wg.Done()
 			}
 		}()
 	}
@@ -133,7 +134,6 @@ func (a *App) Rebuild() {
 			if valid(i) {
 				for _, j := range get_files(fmt.Sprintf("http://%s/%s/", tvol, i.Name)) {
 					if valid(j) {
-						wg.Add(1)
 						url := fmt.Sprintf("http://%s/%s/%s/", tvol, i.Name, j.Name)
 						reqs <- RebuildRequest{tvol, url}
 					}

--- a/tools/bringup.sh
+++ b/tools/bringup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 kill $(pgrep -f nginx)
+kill $(pgrep -f mkv)
 
 PORT=3001 ./volume /tmp/volume1/ &
 PORT=3002 ./volume /tmp/volume2/ &

--- a/tools/thrasher.go
+++ b/tools/thrasher.go
@@ -74,17 +74,17 @@ func main() {
 	// 16 concurrent processes
 	for i := 0; i < 16; i++ {
 		go func() {
-			for {
-				key := <-reqs
-				value := fmt.Sprintf("value-%d", rand.Int())
-				if err := remote_put("http://localhost:3000/"+key, int64(len(value)), strings.NewReader(value)); err != nil {
+			for key := range reqs {
+				value := make([]byte, 1024*1024) // 1MB
+				rand.Read(value)
+				if err := remote_put("http://localhost:3000/"+key, int64(len(value)), bytes.NewReader(value)); err != nil {
 					fmt.Println("PUT FAILED", err)
 					resp <- false
 					continue
 				}
 
 				ss, err := remote_get("http://localhost:3000/" + key)
-				if err != nil || ss != value {
+				if err != nil || ss != string(value) {
 					fmt.Println("GET FAILED", err, ss, value)
 					resp <- false
 					continue

--- a/tools/thrasher.go
+++ b/tools/thrasher.go
@@ -74,17 +74,17 @@ func main() {
 	// 16 concurrent processes
 	for i := 0; i < 16; i++ {
 		go func() {
-			for key := range reqs {
-				value := make([]byte, 1024*1024) // 1MB
-				rand.Read(value)
-				if err := remote_put("http://localhost:3000/"+key, int64(len(value)), bytes.NewReader(value)); err != nil {
+			for {
+				key := <-reqs
+				value := fmt.Sprintf("value-%d", rand.Int())
+				if err := remote_put("http://localhost:3000/"+key, int64(len(value)), strings.NewReader(value)); err != nil {
 					fmt.Println("PUT FAILED", err)
 					resp <- false
 					continue
 				}
 
 				ss, err := remote_get("http://localhost:3000/" + key)
-				if err != nil || ss != string(value) {
+				if err != nil || ss != value {
 					fmt.Println("GET FAILED", err, ss, value)
 					resp <- false
 					continue


### PR DESCRIPTION
- Writes are done sequentially, don't see a reason why they should;
- Simplify sync.WaitGroup usage: no need to bump the counter on each task, only per goroutine;
- Panic on failure to bind to a port instead of silently exiting;